### PR TITLE
Disable npm lifecycle scripts for security

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,6 @@
 # List the start up tasks. Learn more https://www.gitpod.io/docs/config-start-tasks/
 tasks:
-  - init: npm install # runs during prebuild
+  - init: npm install --ignore-scripts # runs during prebuild
     command: npm start
 
 # List the ports to expose. Learn more https://www.gitpod.io/docs/config-ports/


### PR DESCRIPTION
Add `--ignore-scripts` flag to npm install to prevent execution of potentially malicious scripts during package installation.

Related to [PDE-128](https://linear.app/ona-team/issue/PDE-128/parent-issue-disabling-npm-lifecycle-scripts)